### PR TITLE
Vimeo support

### DIFF
--- a/embed.js
+++ b/embed.js
@@ -14,7 +14,7 @@ var IRCCloudEmbed = function() {
     }
 
     function is_youtube(href) {
-        return youtube_parser(href) != false;
+        return youtube_parser(href) !== false;
     }
 
     function embed_image(message_row, href) {


### PR DESCRIPTION
IRCCloud Embed now supports Vimeo videos. It's even smart enough to pick out the video ID from fancy group URLs like this one!

[http://vimeo.com/groups/162540/videos/51324794](http://vimeo.com/groups/162540/videos/51324794)

A lot of this code is a copy of what the YouTube one does, so there are definitely lines that can be cut in cleanup.
