### PR TITLE
Vimeo support (fixed this time)

### DIFF
--- a/embed.js
+++ b/embed.js
@@ -16,6 +16,8 @@ var IRCCloudEmbed = function() {
         if(match) {
             return match[3];
         }
+
+        return false;
     }
 
     function is_image_href(href) {


### PR DESCRIPTION
This one should be all good. Added the `return false;` that was missing in the Vimeo video check. Now it doesn't try to Vimeo-ify everything.
